### PR TITLE
Feature/use lazy enumerator

### DIFF
--- a/lib/morphy.rb
+++ b/lib/morphy.rb
@@ -10,13 +10,13 @@ module Morphy
     end
 
     def query(word)
-      results = @dawg.query(word).select { |result| result.present? }
-      results = results.map do |result|
-        result = result.to_s
-        word, para_id, index = result.split(' ')
+      entries = @dawg.query(word)
+
+      entries.lazy.map do |row|
+        next unless row.present?
+        word, para_id, index = row.to_s.split(' ')
         Word.new(word, para_id, index)
       end
-      results
     end
 
     def to_s

--- a/lib/morphy.rb
+++ b/lib/morphy.rb
@@ -10,7 +10,7 @@ module Morphy
     end
 
     def query(word)
-      results = @dawg.query(word)
+      results = @dawg.query(word).select { |result| result.present? }
       results = results.map do |result|
         result = result.to_s
         word, para_id, index = result.split(' ')


### PR DESCRIPTION
with [lazy dawg](https://github.com/baltavay/dawg/pull/1) the first result will return faster
```ruby
morphy = Morphy.new
Benchmark.measure { morphy.query('пост').first }

# regular: 1.416946840006858
# lazy:    0.0003661399823613465
```

